### PR TITLE
deprecated: sphinx-inline-tabs extensions

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -55,7 +55,6 @@ parse:
 sphinx:
   extra_extensions:
     - sphinxcontrib.mermaid
-    - sphinx_inline_tabs
     - sphinxcontrib.proof
   local_extensions          :   # A list of local extensions to load by sphinx specified by "name: path" items
   config                    :   # key-value pairs to directly over-ride the Sphinx configuration

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -1,5 +1,4 @@
 jupyter-book>=0.15.0,<0.16.0
 jupytext
 sphinxcontrib-mermaid
-sphinx-inline-tabs
 sphinxcontrib-proof


### PR DESCRIPTION
Похоже, контент был обновлен уже.

Closes #56.